### PR TITLE
Set timezone to UTC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
       POSTGRES_DB: ${DB_NAME}
-      TZ: 'GMT+2'
-      PGTZ: 'GMT+2'
+      TZ: "UTC"
+      PGTZ: "UTC"
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description

The timezone of postgres was set to GMT+2. However, go does not read the timezone and assumes that timestamps from the db are in UTC, leading to errors. I would suggest to stick to UTC and only change the timezone in the UI when timestamps are displayed.

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works