### PR TITLE
Do not include LicenseItem in Sale via IsSale attribute

### DIFF
--- a/app/database/methods.go
+++ b/app/database/methods.go
@@ -1,10 +1,13 @@
 package database
 
 // GetTotal returns the total amount of a payment order in cents
+// Only entries that are part of the sale are counted
 func (order Order) GetTotal() (amount int) {
 	amount = 0
-	for _, item := range order.Entries {
-		amount += item.Price * item.Quantity
+	for _, entry := range order.Entries {
+		if entry.IsSale {
+			amount += entry.Price * entry.Quantity
+		}
 	}
 	return amount
 }

--- a/app/database/queries.go
+++ b/app/database/queries.go
@@ -217,14 +217,14 @@ func (db *Database) DeleteItem(id int) (err error) {
 
 // GetOrderEntries returns all entries of an order
 func (db *Database) GetOrderEntries(orderID int) (entries []OrderEntry, err error) {
-	rows, err := db.Dbpool.Query(context.Background(), "SELECT ID, Item, Quantity, Price, Sender, Receiver FROM OrderEntry WHERE paymentorder = $1", orderID)
+	rows, err := db.Dbpool.Query(context.Background(), "SELECT ID, Item, Quantity, Price, Sender, Receiver, IsSale FROM OrderEntry WHERE paymentorder = $1", orderID)
 	if err != nil {
 		log.Error(err)
 		return
 	}
 	for rows.Next() {
 		var entry OrderEntry
-		err = rows.Scan(&entry.ID, &entry.Item, &entry.Quantity, &entry.Price, &entry.Sender, &entry.Receiver)
+		err = rows.Scan(&entry.ID, &entry.Item, &entry.Quantity, &entry.Price, &entry.Sender, &entry.Receiver, &entry.IsSale)
 		if err != nil {
 			log.Error(err)
 			return
@@ -330,7 +330,7 @@ func createOrderEntryTx(tx pgx.Tx, orderID int, entry OrderEntry) (OrderEntry, e
 	entry.Price = item.Price
 
 	// Create order entry
-	err = tx.QueryRow(context.Background(), "INSERT INTO OrderEntry (Item, Price, Quantity, PaymentOrder, Sender, Receiver) values ($1, $2, $3, $4, $5, $6) RETURNING ID", entry.Item, entry.Price, entry.Quantity, orderID, entry.Sender, entry.Receiver).Scan(&entry.ID)
+	err = tx.QueryRow(context.Background(), "INSERT INTO OrderEntry (Item, Price, Quantity, PaymentOrder, Sender, Receiver, IsSale) values ($1, $2, $3, $4, $5, $6, $7) RETURNING ID", entry.Item, entry.Price, entry.Quantity, orderID, entry.Sender, entry.Receiver, entry.IsSale).Scan(&entry.ID)
 	if err != nil {
 		log.Error(err)
 	}
@@ -353,6 +353,7 @@ func createPaymentForOrderEntryTx(tx pgx.Tx, orderID int, entry OrderEntry, erro
 			Amount:   entry.Price * entry.Quantity,
 			Order:    null.NewInt(int64(orderID), true),
 			OrderEntry: null.NewInt(int64(entry.ID), true),
+			IsSale:   entry.IsSale,
 		}
 		paymentID, err = createPaymentTx(tx, payment)
 	}
@@ -444,7 +445,7 @@ func (db *Database) ListPayments(minDate time.Time, maxDate time.Time) (payments
 	// Scan rows
 	for rows.Next() {
 		var payment Payment
-		err = rows.Scan(&payment.ID, &payment.Timestamp, &payment.Sender, &payment.Receiver, &payment.Amount, &payment.AuthorizedBy, &payment.Order, &payment.OrderEntry)
+		err = rows.Scan(&payment.ID, &payment.Timestamp, &payment.Sender, &payment.Receiver, &payment.Amount, &payment.AuthorizedBy, &payment.Order, &payment.OrderEntry, &payment.IsSale)
 		if err != nil {
 			return payments, err
 		}
@@ -455,7 +456,7 @@ func (db *Database) ListPayments(minDate time.Time, maxDate time.Time) (payments
 
 // GetPayment
 func (db *Database) GetPayment(id int) (payment Payment, err error) {
-	err = db.Dbpool.QueryRow(context.Background(), "SELECT * FROM Payment WHERE ID = $1", id).Scan(&payment.ID, &payment.Timestamp, &payment.Sender, &payment.Receiver, &payment.Amount, &payment.AuthorizedBy, &payment.Order, &payment.OrderEntry)
+	err = db.Dbpool.QueryRow(context.Background(), "SELECT * FROM Payment WHERE ID = $1", id).Scan(&payment.ID, &payment.Timestamp, &payment.Sender, &payment.Receiver, &payment.Amount, &payment.AuthorizedBy, &payment.Order, &payment.OrderEntry, &payment.IsSale)
 	if err != nil {
 		log.Error(err)
 	}
@@ -473,7 +474,7 @@ func createPaymentTx(tx pgx.Tx, payment Payment) (paymentID int, err error) {
 	}
 
 	// Create payment
-	err = tx.QueryRow(context.Background(), "INSERT INTO Payment (Sender, Receiver, Amount, AuthorizedBy, PaymentOrder, OrderEntry) values ($1, $2, $3, $4, $5, $6) RETURNING ID", payment.Sender, payment.Receiver, payment.Amount, payment.AuthorizedBy, payment.Order, payment.OrderEntry).Scan(&paymentID)
+	err = tx.QueryRow(context.Background(), "INSERT INTO Payment (Sender, Receiver, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale) values ($1, $2, $3, $4, $5, $6, $7) RETURNING ID", payment.Sender, payment.Receiver, payment.Amount, payment.AuthorizedBy, payment.Order, payment.OrderEntry, payment.IsSale).Scan(&paymentID)
 	if err != nil {
 		log.Error(err)
 		return

--- a/app/database/types.go
+++ b/app/database/types.go
@@ -67,6 +67,7 @@ type OrderEntry struct {
 	Price    int // Price at time of purchase in cents
 	Sender   int
 	Receiver int
+	IsSale   bool // Whether to include this item in sales payment
 }
 
 // Payment is a struct that is used for the payment table
@@ -79,6 +80,7 @@ type Payment struct {
 	AuthorizedBy string
 	Order        null.Int `swaggertype:"integer"`
 	OrderEntry   null.Int `swaggertype:"integer"`
+	IsSale       bool
 }
 
 // Settings is a struct that is used for the settings table

--- a/app/handlers/handlers.go
+++ b/app/handlers/handlers.go
@@ -420,6 +420,7 @@ func CreatePaymentOrder(w http.ResponseWriter, r *http.Request) {
 		order.Entries[idx].Sender = buyerAccountID
 		order.Entries[idx].Receiver = vendorAccount.ID
 		order.Entries[idx].Price = item.Price // Take current item price
+		order.Entries[idx].IsSale = true  // Will be used for sales payment
 
 		// If there is a license item, prepend it before the actual item
 		if item.LicenseItem.Valid {

--- a/app/handlers/handlers_test.go
+++ b/app/handlers/handlers_test.go
@@ -173,6 +173,10 @@ func TestOrders(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Test order amount
+	orderTotal := order.GetTotal()
+	require.Equal(t, orderTotal, 314*315)
+
 	senderAccount, err := database.Db.GetAccountByType("UserAnon")
 	if err != nil {
 		t.Error(err)

--- a/app/handlers/handlers_test.go
+++ b/app/handlers/handlers_test.go
@@ -148,12 +148,31 @@ func TestItems(t *testing.T) {
 
 }
 
+func CreateTestItemWithLicense(t *testing.T) (string, string) {
+	f := `{
+		"Name": "License item",
+		"Price": 123
+	}`
+	res := utils.TestRequestStr(t, r, "POST", "/api/items/", f, 200)
+	licenseItemID := res.Body.String()
+
+	f2 := `{
+		"Name": "Test item",
+		"Price": 314,
+		"LicenseItem": ` + licenseItemID + `
+	}`
+	res2 := utils.TestRequestStr(t, r, "POST", "/api/items/", f2, 200)
+	itemID := res2.Body.String()
+	return itemID, licenseItemID
+}
+
 // TestOrders tests CRUD operations on orders
 // TODO: Test independent of vivawallet
 func TestOrders(t *testing.T) {
 
-	itemID := CreateTestItem(t)
+	itemID, licenseItemID := CreateTestItemWithLicense(t)
 	itemIDInt, _ := strconv.Atoi(itemID)
+	licenseItemIDInt, _ := strconv.Atoi(licenseItemID)
 	vendorID := createTestVendor(t, "testLicenseID2")
 	vendorIDInt, _ := strconv.Atoi(vendorID)
 	f := `{
@@ -186,13 +205,15 @@ func TestOrders(t *testing.T) {
 		t.Error(err)
 	}
 
+
 	require.Equal(t, order.Vendor, vendorIDInt)
 	require.Equal(t, order.Verified, false)
-	require.Equal(t, order.Entries[0].Item, itemIDInt)
-	require.Equal(t, order.Entries[0].Quantity, 315)
-	require.Equal(t, order.Entries[0].Price, 314)
-	require.Equal(t, order.Entries[0].Sender, senderAccount.ID)
-	require.Equal(t, order.Entries[0].Receiver, receiverAccount.ID)
+	require.Equal(t, order.Entries[0].Item, licenseItemIDInt)
+	require.Equal(t, order.Entries[1].Item, itemIDInt)
+	require.Equal(t, order.Entries[1].Quantity, 315)
+	require.Equal(t, order.Entries[1].Price, 314)
+	require.Equal(t, order.Entries[1].Sender, senderAccount.ID)
+	require.Equal(t, order.Entries[1].Receiver, receiverAccount.ID)
 
 }
 

--- a/app/migrations/001_payment_model.sql
+++ b/app/migrations/001_payment_model.sql
@@ -53,7 +53,8 @@ CREATE TABLE OrderEntry (
     Quantity integer NOT NULL DEFAULT 0,
     PaymentOrder integer REFERENCES PaymentOrder,
     Sender integer NOT NULL REFERENCES Account,
-    Receiver integer NOT NULL REFERENCES Account
+    Receiver integer NOT NULL REFERENCES Account,
+    IsSale bool NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE Payment (
@@ -64,7 +65,8 @@ CREATE TABLE Payment (
     Amount integer NOT NULL,  -- Price in cents
     AuthorizedBy varchar(255) NOT NULL DEFAULT '',
     PaymentOrder integer REFERENCES PaymentOrder,
-    OrderEntry integer REFERENCES OrderEntry
+    OrderEntry integer REFERENCES OrderEntry,
+    IsSale bool NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE Settings (


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description

New attribute IsSale for entries & items marks items that are included in the vivawallet payment amount (via order.GetTotal()).

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [x] I have added tests that prove my fix is effective or that my feature works