### PR TITLE
Improve Handler ListVendors by ordering licenseIDs

### DIFF
--- a/app/database/queries.go
+++ b/app/database/queries.go
@@ -52,7 +52,7 @@ func (db *Database) GetHelloWorld() (string, error) {
 
 // ListVendors returns all users from the database but not all fields for better overview
 func (db *Database) ListVendors() (vendors []Vendor, err error) {
-	rows, err := db.Dbpool.Query(context.Background(), "SELECT vendor.ID, LicenseID, FirstName, LastName, LastPayout, Balance from Vendor JOIN account ON account.vendor = vendor.id")
+	rows, err := db.Dbpool.Query(context.Background(), "SELECT vendor.ID, LicenseID, FirstName, LastName, LastPayout, Balance from Vendor JOIN account ON account.vendor = vendor.id ORDER BY LicenseID ASC")
 	if err != nil {
 		log.Error(err)
 		return vendors, err

--- a/app/database/queries.go
+++ b/app/database/queries.go
@@ -515,6 +515,8 @@ func (db *Database) ListPayments(minDate time.Time, maxDate time.Time, vendorLic
 	if len(filters) > 0 {
 		query += " WHERE " + strings.Join(filters, " AND ")
 	}
+	// Order by timestamp
+	query += " ORDER BY Payment.Timestamp"
 	rows, err = db.Dbpool.Query(context.Background(), query, filterValues...)
 	if err != nil {
 		log.Error(err)
@@ -531,7 +533,7 @@ func (db *Database) ListPayments(minDate time.Time, maxDate time.Time, vendorLic
 		}
 
 		// Add payout payments to main payment
-		subrows, err := db.Dbpool.Query(context.Background(), "SELECT ID, Timestamp, Sender, Receiver, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale, Payout, Item, Quantity, Price FROM Payment WHERE Payout = $1", payment.ID)
+		subrows, err := db.Dbpool.Query(context.Background(), "SELECT ID, Timestamp, Sender, Receiver, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale, Payout, Item, Quantity, Price FROM Payment WHERE Payout = $1 ORDER BY Timestamp", payment.ID)
 		if err != nil {
 			log.Error(err)
 			return payments, err


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
**IMPORTANT TO KNOW**
<!-- Let your reviewer know if she has to configure something new or somehting has to be thought further or ... -->
Since I have no extended demo data to test with I can just assume, that this command does order the licenseIDs alphabetically but not numerical. 
To order it numerical, we would have to add something like this
```sql
SELECT vendor.ID, LicenseID, FirstName, LastName, LastPayout, Balance
FROM Vendor
JOIN account ON account.vendor = vendor.id
ORDER BY
  SUBSTR(LicenseID, 1, 1),  -- Sort by the letter part
  CAST(SUBSTR(LicenseID, 3) AS SIGNED);  -- Sort by the numeric part
```
This in fact would mean though, we can not apply our ordering list to any other license IDs having more than one character, which would contradict to our generalisition approach... 
What do you think?

**CHANGES**
<!-- Let your reviewer know what changes happened in this PR ... -->
- Solves issue of unordered Vendors list by ordering it by their licenseID
- Solves issues of unordered Payments considering the [SQL Query Order of Execution](https://sqlbolt.com/lesson/select_queries_order_of_execution)

**TODO**
<!-- Let your reviewer know if there is still something to do or has to be done in the future i.e. for fine-tuning ... -->
- Checked Order by running commands and not receiving errors but should create more test data to see it correctly ordered 
  - Therefore, I should manipulate the timestamp to -1 day or -1 hour and don't know yet how to arrange it

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works