### PR TITLE
Add lock for updating Balance

### DIFF
--- a/app/database/queries.go
+++ b/app/database/queries.go
@@ -835,21 +835,6 @@ func (db *Database) GetAccountByType(accountType string) (account Account, err e
 	return
 }
 
-// UpdateAccountBalance updates the balance of an account
-func (db *Database) UpdateAccountBalance(id int, balanceDiff int) (err error) {
-
-	// Start a transaction
-	tx, err := db.Dbpool.Begin(context.Background())
-	if err != nil {
-		return err
-	}
-	defer func() { err = deferTx(tx, err) }()
-
-	err = updateAccountBalanceTx(tx, id, balanceDiff)
-
-	return
-}
-
 // updateAccountBalanceTx updates the balance of an account in an transaction
 func updateAccountBalanceTx(tx pgx.Tx, id int, balanceDiff int) (err error) {
 
@@ -871,20 +856,6 @@ func updateAccountBalanceTx(tx pgx.Tx, id int, balanceDiff int) (err error) {
 	if err != nil {
 		log.Error(err)
 	}
-
-	// Diffferent approach via pg_advisory_lock, which lead to an error
-	// https://stackoverflow.com/a/55267440/19932351
-	// err = tx.QueryRow(context.Background(), "SELECT pg_advisory_lock(Balance) FROM Account WHERE ID = $1", id).Scan(&account.Balance)
-	// if err != nil {
-	// 	log.Error(err)
-	// }
-
-	//Update balance
-
-	// err = tx.QueryRow(context.Background(), "SELECT pg_advisory_unlock(Balance) FROM Account WHERE ID = $1", id).Scan(&account.Balance)
-	// if err != nil {
-	// 	log.Error(err)
-	// }
 
 	return
 }


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
**IMPORTANT TO KNOW**
<!-- Let your reviewer know if she has to configure something new or somehting has to be thought further or ... -->
- Both approaches come from a SO blog
1. [https://stackoverflow.com/questions/45867537/force-a-lock-with-postgres-and-go](https://stackoverflow.com/questions/45867537/force-a-lock-with-postgres-and-go)
2. [https://stackoverflow.com/a/55267440/19932351](https://stackoverflow.com/a/55267440/19932351)

- Decided for a database lock in PostgreSQL and against a Go lock like shown in [this tutorial](https://gobyexample.com/mutexes)


**CHANGES**
<!-- Let your reviewer know what changes happened in this PR ... -->
- Add lock to balances update


**TODO**
<!-- Let your reviewer know if there is still something to do or has to be done in the future i.e. for fine-tuning ... -->
- Test that this is working

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works